### PR TITLE
Improve use of contexts to ensure goroutine shutdown

### DIFF
--- a/ndt-server.go
+++ b/ndt-server.go
@@ -44,7 +44,6 @@ const (
 const (
 	cReadyC2S = float64(-1)
 	cReadyS2C = float64(-1)
-	cError    = float64(-2)
 )
 
 // Flags that can be passed in on the command line
@@ -321,8 +320,9 @@ func (tr *TestResponder) C2STestServer(w http.ResponseWriter, r *http.Request) {
 	tr.response <- bytesPerSecond
 
 	// Drain client for a few more seconds, and discard results.
+	deadline, _ := tr.ctx.Deadline()
 	tr.cancel()
-	tr.ctx, tr.cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	tr.ctx, tr.cancel = context.WithDeadline(context.Background(), deadline)
 	_ = tr.recvC2SUntil(ws)
 }
 
@@ -604,7 +604,7 @@ This is an NDT server.
 
 It only works with Websockets and SSL.
 
-You can run a test here: /static/widget.html
+You can run a test here: :3010/static/widget.html
 You can monitor its status on port :9090/metrics.
 `))
 }

--- a/ndt-server_test.go
+++ b/ndt-server_test.go
@@ -65,8 +65,8 @@ func Test_NDTe2e(t *testing.T) {
 			name: "Upload & Download with S2C Timeout",
 			cmd: "node ./testdata/unittest_client.js --server=" + u.Hostname() +
 				" --port=" + u.Port() +
-				" --protocol=wss --acceptinvalidcerts --tests=22 & " +
-				"sleep 1 && kill $(jobs -p) && sleep 25",
+				" --protocol=wss --acceptinvalidcerts --abort-c2s-early --tests=22 & " +
+				"sleep 25",
 		},
 	}
 

--- a/ndt-server_test.go
+++ b/ndt-server_test.go
@@ -66,7 +66,7 @@ func Test_NDTe2e(t *testing.T) {
 			cmd: "node ./testdata/unittest_client.js --server=" + u.Hostname() +
 				" --port=" + u.Port() +
 				" --protocol=wss --acceptinvalidcerts --tests=22 & " +
-				"sleep 1 && kill %1 && sleep 25",
+				"sleep 1 && kill $(jobs -p) && sleep 25",
 		},
 	}
 

--- a/testdata/unittest_client.js
+++ b/testdata/unittest_client.js
@@ -22,7 +22,8 @@ var argv = require('minimist')(process.argv.slice(2),
                                             'port': 3001,
                                             'protocol': 'ws',
                                             'tests': (2 | 4 | 32),
-                                            'acceptinvalidcerts': false},
+                                            'acceptinvalidcerts': false,
+                                            'abort-c2s-early': false},
                                 'string': ['server'],
                                 'boolean': [ 'quiet', 'debug']}),
     COMM_FAILURE = 0,
@@ -45,6 +46,7 @@ var argv = require('minimist')(process.argv.slice(2),
     server = argv['server'],
     port = argv['port'],
     tests = argv['tests'],
+    abort_c2s_early = argv['abort-c2s-early'],
     url_protocol = argv['protocol'],
     debug = !!(argv.debug),
     quiet = !!(argv.quiet),
@@ -279,6 +281,9 @@ function ndt_c2s_test() {
             return "KEEP GOING";
         }
         if (state === "WAIT_FOR_TEST_START" && type === TEST_START) {
+            if (abort_c2s_early) {
+                die("C2S: aborting early as requested.");
+            }
             test_start = Date.now() / 1000;
             keep_sending_data();
             state = "WAIT_FOR_TEST_MSG";


### PR DESCRIPTION
During canary deployment at tyo02, we found that there were goroutines blocked indefinitely in `manageC2sTest` (called from the control channel) waiting for a client test to run that never came.

This change improves the use of context in the control channel and TestResponder goroutines to ensure that all goroutines eventually exit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-cloud/13)
<!-- Reviewable:end -->
