### PR TITLE
Begin refactoring ndt-cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-[![GoDoc](https://godoc.org/github.com/m-lab/ndt-cloud?status.svg)](https://godoc.org/github.com/m-lab/ndt-cloud) [![Build Status](https://travis-ci.org/m-lab/ndt-cloud.svg?branch=master)](https://travis-ci.org/m-lab/ndt-cloud) [![Coverage Status](https://coveralls.io/repos/github/m-lab/ndt-cloud/badge.svg?branch=master)](https://coveralls.io/github/m-lab/ndt-cloud?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/m-lab/ndt-cloud)](https://goreportcard.com/report/github.com/m-lab/ndt-cloud)
-
 # ndt-cloud
 
-To run the server locally, first run `gen_local_test_certs.sh`, and then run the
-commands
+[![GoDoc](https://godoc.org/github.com/m-lab/ndt-cloud?status.svg)](https://godoc.org/github.com/m-lab/ndt-cloud) [![Build Status](https://travis-ci.org/m-lab/ndt-cloud.svg?branch=master)](https://travis-ci.org/m-lab/ndt-cloud) [![Coverage Status](https://coveralls.io/repos/github/m-lab/ndt-cloud/badge.svg?branch=master)](https://coveralls.io/github/m-lab/ndt-cloud?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/m-lab/ndt-cloud)](https://goreportcard.com/report/github.com/m-lab/ndt-cloud)
+
+To run the server locally, first generate self-signed certs and build the docker
+image.
+
 ```bash
+./gen_local_test_certs.sh
 docker build . -t ndt-cloud
 ```
-and
+
+Next, run the docker image with flags that reference the local cert and key.
+
 ```bash
 docker run --net=host -v `pwd`:/certs -it -t ndt-cloud \
     -cert /certs/cert.pem -key /certs/key.pem

--- a/legacy/c2s.go
+++ b/legacy/c2s.go
@@ -26,10 +26,9 @@ func (tr *Responder) C2STestHandler(w http.ResponseWriter, r *http.Request) {
 	// Define an absolute deadline for running all tests.
 	deadline := time.Now().Add(tr.duration)
 
-	// Signal ready, and run the test.
+	// Signal control channel we're ready, and run the test.
 	tr.result <- cReadyC2S
-	bytesPerSecond := runC2S(ws, deadline.Sub(time.Now()), true)
-	tr.result <- bytesPerSecond
+	tr.result <- runC2S(ws, deadline.Sub(time.Now()), true)
 
 	// Drain client for a few more seconds, and discard results.
 	_ = runC2S(ws, deadline.Sub(time.Now()), false)

--- a/legacy/c2s.go
+++ b/legacy/c2s.go
@@ -1,0 +1,106 @@
+package legacy
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/m-lab/ndt-cloud/ndt"
+)
+
+// C2STestHandler is an http.Handler that executes the NDT c2s test over websockets.
+func (tr *Responder) C2STestHandler(w http.ResponseWriter, r *http.Request) {
+	upgrader := MakeNdtUpgrader([]string{"c2s"})
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		// Upgrade should have already returned an HTTP error code.
+		log.Println("ERROR C2S: upgrader", err)
+		return
+	}
+	defer ws.Close()
+
+	// Define an absolute deadline for running all tests.
+	deadline := time.Now().Add(tr.duration)
+
+	// Signal ready, and run the test.
+	tr.Result <- cReadyC2S
+	bytesPerSecond := runC2S(ws, deadline.Sub(time.Now()), true)
+	tr.Result <- bytesPerSecond
+
+	// Drain client for a few more seconds, and discard results.
+	_ = runC2S(ws, deadline.Sub(time.Now()), false)
+}
+
+// C2SController manages communication with the C2STestHandler from the control
+// channel.
+func (tr *Responder) C2SController(ws *websocket.Conn) (float64, error) {
+	// Wait for test to run.
+	// Send the server port to the client.
+	SendNdtMessage(ndt.TestPrepare, strconv.Itoa(tr.Port), ws)
+	c2sReady := <-tr.Result
+	if c2sReady != cReadyC2S {
+		return 0, fmt.Errorf("ERROR C2S: Bad value received on the c2s channel: %f", c2sReady)
+	}
+	SendNdtMessage(ndt.TestStart, "", ws)
+	c2sBytesPerSecond := <-tr.Result
+	c2sKbps := 8 * c2sBytesPerSecond / 1000.0
+
+	SendNdtMessage(ndt.TestMsg, fmt.Sprintf("%.4f", c2sKbps), ws)
+	SendNdtMessage(ndt.TestFinalize, "", ws)
+	log.Println("C2S: server rate:", c2sKbps)
+	return c2sKbps, nil
+}
+
+// runC2S performs a 10 second NDT client to server test. Runtime is
+// guaranteed to be no more than timeout. The timeout should be slightly greater
+// than 10 sec. The given websocket should be closed by the caller.
+func runC2S(ws *websocket.Conn, timeout time.Duration, logErrors bool) float64 {
+	done := make(chan float64)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// Run recv in background.
+	go func() {
+		bytesPerSec, err := recvUntil(ws, 10*time.Second)
+		if err != nil {
+			cancel()
+			if logErrors {
+				log.Println("C2S: recvUntil error:", err)
+			}
+			return
+		}
+		done <- bytesPerSec
+	}()
+
+	select {
+	case <-ctx.Done():
+		if logErrors {
+			log.Println("C2S: Context Done!", ctx.Err())
+		}
+		// Return zero on error.
+		return 0
+	case bytesPerSecond := <-done:
+		return bytesPerSecond
+	}
+}
+
+// recvUntil reads from the given websocket for duration seconds and returns the
+// average rate.
+func recvUntil(ws *websocket.Conn, duration time.Duration) (float64, error) {
+	totalBytes := float64(0)
+	startTime := time.Now()
+	endTime := startTime.Add(duration)
+	for time.Now().Before(endTime) {
+		_, buffer, err := ws.ReadMessage()
+		if err != nil {
+			return 0, err
+		}
+		totalBytes += float64(len(buffer))
+	}
+	bytesPerSecond := totalBytes / float64(time.Since(startTime)/time.Second)
+	return bytesPerSecond, nil
+}

--- a/legacy/message.go
+++ b/legacy/message.go
@@ -1,0 +1,80 @@
+package legacy
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gorilla/websocket"
+)
+
+// NdtJSONMessage holds the JSON messages we can receive from the server. We
+// only support the subset of the NDT JSON protocol that has two fields: msg,
+// and tests.
+type NdtJSONMessage struct {
+	Msg   string `json:"msg"`
+	Tests string `json:"tests,omitempty"`
+}
+
+func (n *NdtJSONMessage) String() string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}
+
+// NdtS2CResult is the result object returned to S2C clients as JSON.
+type NdtS2CResult struct {
+	ThroughputValue  float64
+	UnsentDataAmount int64
+	TotalSentByte    int64
+}
+
+func (n *NdtS2CResult) String() string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}
+
+func readNdtMessage(ws *websocket.Conn, expectedType byte) ([]byte, error) {
+	_, inbuff, err := ws.ReadMessage()
+	if err != nil {
+		return nil, err
+	}
+	if inbuff[0] != expectedType {
+		return nil, fmt.Errorf("Read wrong message type. Wanted 0x%x, got 0x%x", expectedType, inbuff[0])
+	}
+	// Verify that the expected length matches the given data.
+	expectedLen := int(inbuff[1])<<8 + int(inbuff[2])
+	if expectedLen != len(inbuff[3:]) {
+		return nil, fmt.Errorf("Message length (%d) does not match length of data received (%d)",
+			expectedLen, len(inbuff[3:]))
+	}
+	return inbuff[3:], nil
+}
+
+func WriteNdtMessage(ws *websocket.Conn, msgType byte, msg fmt.Stringer) error {
+	message := msg.String()
+	outbuff := make([]byte, 3+len(message))
+	outbuff[0] = msgType
+	outbuff[1] = byte((len(message) >> 8) & 0xFF)
+	outbuff[2] = byte(len(message) & 0xFF)
+	for i := range message {
+		outbuff[i+3] = message[i]
+	}
+	return ws.WriteMessage(websocket.BinaryMessage, outbuff)
+}
+
+func RecvNdtJSONMessage(ws *websocket.Conn, expectedType byte) (*NdtJSONMessage, error) {
+	message := &NdtJSONMessage{}
+	jsonString, err := readNdtMessage(ws, expectedType)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(jsonString, &message)
+	if err != nil {
+		return nil, err
+	}
+	return message, nil
+}
+
+func SendNdtMessage(msgType byte, msg string, ws *websocket.Conn) error {
+	message := &NdtJSONMessage{Msg: msg}
+	return WriteNdtMessage(ws, msgType, message)
+}

--- a/legacy/responder.go
+++ b/legacy/responder.go
@@ -1,16 +1,12 @@
 package legacy
 
 import (
-	"context"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/m-lab/ndt-cloud/ndt"
 )
 
 // Message constants for use in their respective channels
@@ -60,49 +56,6 @@ func (tr *Responder) StartTLSAsync(mux *http.ServeMux) error {
 	return nil
 }
 
-// C2STestHandler is an http.Handler that executes the NDT c2s test over websockets.
-func (tr *Responder) C2STestHandler(w http.ResponseWriter, r *http.Request) {
-	upgrader := makeNdtUpgrader([]string{"c2s"})
-	ws, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		// Upgrade should have already returned an HTTP error code.
-		log.Println("ERROR C2S: upgrader", err)
-		return
-	}
-	defer ws.Close()
-
-	// Define an absolute deadline for running all tests.
-	deadline := time.Now().Add(tr.duration)
-
-	// Signal ready, and run the test.
-	tr.Result <- cReadyC2S
-	bytesPerSecond := runC2S(ws, deadline.Sub(time.Now()), true)
-	tr.Result <- bytesPerSecond
-
-	// Drain client for a few more seconds, and discard results.
-	_ = runC2S(ws, deadline.Sub(time.Now()), false)
-}
-
-// C2SController manages communication with the C2STestHandler from the control
-// channel.
-func (tr *Responder) C2SController(ws *websocket.Conn) (float64, error) {
-	// Wait for test to run.
-	// Send the server port to the client.
-	SendNdtMessage(ndt.TestPrepare, strconv.Itoa(tr.Port), ws)
-	c2sReady := <-tr.Result
-	if c2sReady != cReadyC2S {
-		return 0, fmt.Errorf("ERROR C2S: Bad value received on the c2s channel")
-	}
-	SendNdtMessage(ndt.TestStart, "", ws)
-	c2sBytesPerSecond := <-tr.Result
-	c2sKbps := 8 * c2sBytesPerSecond / 1000.0
-
-	SendNdtMessage(ndt.TestMsg, fmt.Sprintf("%.4f", c2sKbps), ws)
-	SendNdtMessage(ndt.TestFinalize, "", ws)
-	log.Println("C2S: server rate:", c2sKbps)
-	return c2sKbps, nil
-}
-
 // Close will shutdown, cancel, or close all resources used by the test.
 func (tr *Responder) Close() {
 	log.Printf("Closing %s Responder", tr.kind)
@@ -118,57 +71,9 @@ func (tr *Responder) Close() {
 	close(tr.Result)
 }
 
-// runC2S performs a 10 second NDT client to server test. Runtime is
-// guaranteed to be no more than timeout. The timeout should be slightly greater
-// than 10 sec. The given websocket should be closed by the caller.
-func runC2S(ws *websocket.Conn, timeout time.Duration, logErrors bool) float64 {
-	done := make(chan float64)
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	// Run recv in background.
-	go func() {
-		bytesPerSec, err := recvUntil(ws, 10*time.Second)
-		if err != nil {
-			cancel()
-			if logErrors {
-				log.Println("C2S: recvUntil error:", err)
-			}
-			return
-		}
-		done <- bytesPerSec
-	}()
-
-	select {
-	case <-ctx.Done():
-		if logErrors {
-			log.Println("C2S: Context Done!", ctx.Err())
-		}
-		// Return zero on error.
-		return 0
-	case bytesPerSecond := <-done:
-		return bytesPerSecond
-	}
-}
-
-// recvUntil reads from the given websocket for duration seconds and returns the
-// average rate.
-func recvUntil(ws *websocket.Conn, duration time.Duration) (float64, error) {
-	totalBytes := float64(0)
-	startTime := time.Now()
-	endTime := startTime.Add(duration)
-	for time.Now().Before(endTime) {
-		_, buffer, err := ws.ReadMessage()
-		if err != nil {
-			return 0, err
-		}
-		totalBytes += float64(len(buffer))
-	}
-	bytesPerSecond := totalBytes / float64(time.Since(startTime)/time.Second)
-	return bytesPerSecond, nil
-}
-
-func makeNdtUpgrader(protocols []string) websocket.Upgrader {
+// MakeNdtUpgrader returns a websocket.Upgrader suitable for a legacy NDT upload
+// or download test.
+func MakeNdtUpgrader(protocols []string) websocket.Upgrader {
 	return websocket.Upgrader{
 		ReadBufferSize:    81920,
 		WriteBufferSize:   81920,

--- a/legacy/responder.go
+++ b/legacy/responder.go
@@ -1,0 +1,206 @@
+package legacy
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/m-lab/ndt-cloud/ndt"
+)
+
+// Message constants for use in their respective channels
+const (
+	cReadyC2S = float64(-1)
+	cReadyS2C = float64(-1)
+)
+
+// Responder coordinates the main control loop and subtests.
+type Responder struct {
+	Port   int
+	Result chan float64
+
+	kind     string
+	duration time.Duration
+	certFile string
+	keyFile  string
+
+	ln net.Listener
+	s  *http.Server
+}
+
+// NewResponder creates a new Responder instance.
+func NewResponder(kind string, duration time.Duration, certFile, keyFile string) *Responder {
+	return &Responder{kind: kind, duration: duration, certFile: certFile, keyFile: keyFile}
+}
+
+// StartTLSAsync allocates a new TLS HTTP server listening on a random port. The
+// server can be stopped again using TestResponder.Close().
+func (tr *Responder) StartTLSAsync(mux *http.ServeMux) error {
+	tr.Result = make(chan float64)
+	ln, port, err := listenRandom()
+	if err != nil {
+		log.Println("ERROR: Failed to listen on any port:", err)
+		return err
+	}
+	tr.Port = port
+	tr.ln = ln
+	tr.s = &http.Server{Handler: mux}
+	go func() {
+		log.Printf("%s: Serving for test on %s", tr.kind, ln.Addr())
+		err := tr.s.ServeTLS(ln, tr.certFile, tr.keyFile)
+		if err != nil && err != http.ErrServerClosed {
+			log.Printf("ERROR: %s Starting TLS server: %s", tr.kind, err)
+		}
+	}()
+	return nil
+}
+
+// C2STestServer is an http.Handler that executes the NDT c2s test over websockets.
+func (tr *Responder) C2STestServer(w http.ResponseWriter, r *http.Request) {
+	upgrader := makeNdtUpgrader([]string{"c2s"})
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		// Upgrade should have already returned an HTTP error code.
+		log.Println("ERROR C2S: upgrader", err)
+		return
+	}
+	defer ws.Close()
+
+	// Define an absolute deadline for running all tests.
+	deadline := time.Now().Add(tr.duration)
+
+	// Signal ready, and run the test.
+	tr.Result <- cReadyC2S
+	bytesPerSecond := runC2S(ws, deadline.Sub(time.Now()))
+	tr.Result <- bytesPerSecond
+
+	// Drain client for a few more seconds, and discard results.
+	_ = runC2S(ws, deadline.Sub(time.Now()))
+}
+
+func (tr *Responder) ControlC2S(ws *websocket.Conn) (float64, error) {
+	// Wait for test to run. ///////////////////////////////////////////
+	// Send the server port to the client.
+	SendNdtMessage(ndt.TestPrepare, strconv.Itoa(tr.Port), ws)
+	c2sReady := <-tr.Result
+	if c2sReady != cReadyC2S {
+		return 0, fmt.Errorf("ERROR C2S: Bad value received on the c2s channel")
+	}
+	SendNdtMessage(ndt.TestStart, "", ws)
+	c2sBytesPerSecond := <-tr.Result
+	c2sKbps := 8 * c2sBytesPerSecond / 1000.0
+
+	SendNdtMessage(ndt.TestMsg, fmt.Sprintf("%.4f", c2sKbps), ws)
+	SendNdtMessage(ndt.TestFinalize, "", ws)
+	log.Println("C2S: server rate:", c2sKbps)
+	return c2sKbps, nil
+}
+
+// Close will shutdown, cancel, or close all resources used by the test.
+func (tr *Responder) Close() {
+	log.Printf("Closing %s Responder", tr.kind)
+	if tr.s != nil {
+		// Shutdown the server for the test.
+		tr.s.Close()
+	}
+	if tr.ln != nil {
+		// Shutdown the socket listener.
+		tr.ln.Close()
+	}
+	// Close channel for communication between the control routine and test routine.
+	close(tr.Result)
+}
+
+// runC2S performs a 10 second NDT client to server test. Runtime is
+// guaranteed to be no more than timeout. The timeout should be slightly greater
+// than 10 sec. The given websocket should be closed by the caller.
+func runC2S(ws *websocket.Conn, timeout time.Duration) float64 {
+	done := make(chan float64)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// Run recv in background.
+	go func() {
+		bytesPerSec, err := recvUntil(ws, 10*time.Second)
+		if err != nil {
+			cancel()
+			log.Println("C2S: recvUntil error:", err)
+			return
+		}
+		done <- bytesPerSec
+	}()
+
+	select {
+	case <-ctx.Done():
+		log.Println("C2S: Context Done!", ctx.Err())
+		// Return zero on error.
+		return 0
+	case bytesPerSecond := <-done:
+		return bytesPerSecond
+	}
+}
+
+// recvUntil reads from the given websocket for duration seconds and returns the
+// average rate.
+func recvUntil(ws *websocket.Conn, duration time.Duration) (float64, error) {
+	totalBytes := float64(0)
+	startTime := time.Now()
+	endTime := startTime.Add(duration)
+	for time.Now().Before(endTime) {
+		_, buffer, err := ws.ReadMessage()
+		if err != nil {
+			return 0, err
+		}
+		totalBytes += float64(len(buffer))
+	}
+	bytesPerSecond := totalBytes / float64(time.Since(startTime)/time.Second)
+	return bytesPerSecond, nil
+}
+
+func makeNdtUpgrader(protocols []string) websocket.Upgrader {
+	return websocket.Upgrader{
+		ReadBufferSize:    81920,
+		WriteBufferSize:   81920,
+		Subprotocols:      protocols,
+		EnableCompression: false,
+		CheckOrigin: func(r *http.Request) bool {
+			// TODO: make this check more appropriate -- added to get initial html5 widget to work.
+			return true
+		},
+	}
+}
+
+// Listen on a random port.
+func listenRandom() (net.Listener, int, error) {
+	// Start listening
+	ln, err := net.ListenTCP("tcp", &net.TCPAddr{})
+	if err != nil {
+		return nil, 0, err
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	return tcpKeepAliveListener{ln}, port, nil
+}
+
+// Note: Copied from net/http package.
+// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
+// connections. It's used by ListenAndServe and ListenAndServeTLS so
+// dead TCP connections (e.g. closing laptop mid-download) eventually
+// go away.
+type tcpKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return nil, err
+	}
+	tc.SetKeepAlive(true)
+	tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}

--- a/legacy/s2c.go
+++ b/legacy/s2c.go
@@ -1,0 +1,128 @@
+package legacy
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/m-lab/ndt-cloud/ndt"
+)
+
+// S2CTestHandler is an http.Handler that executes the NDT s2c test over websockets.
+func (tr *Responder) S2CTestHandler(w http.ResponseWriter, r *http.Request) {
+	upgrader := MakeNdtUpgrader([]string{"s2c"})
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		// Upgrade should have already returned an HTTP error code.
+		log.Println("ERROR S2C: upgrader", err)
+		return
+	}
+	defer ws.Close()
+
+	dataToSend := make([]byte, 81920)
+	for i := range dataToSend {
+		dataToSend[i] = byte(((i * 101) % (122 - 33)) + 33)
+	}
+
+	// Define an absolute deadline for running all tests.
+	deadline := time.Now().Add(tr.duration)
+
+	// Signal control channel that we are about to start the test.
+	tr.Result <- cReadyS2C
+	tr.Result <- runS2C(ws, dataToSend, deadline.Sub(time.Now()))
+}
+
+// S2CController manages communication with the S2CTestHandler from the control
+// channel.
+func (tr *Responder) S2CController(ws *websocket.Conn) (float64, error) {
+	// Wait for test to run. ///////////////////////////////////////////
+	// Send the server port to the client.
+	SendNdtMessage(ndt.TestPrepare, strconv.Itoa(tr.Port), ws)
+	s2cReady := <-tr.Result
+	if s2cReady != ndt.ReadyS2C {
+		return 0, fmt.Errorf("ERROR S2C: Bad value received on the s2c channel: %f", s2cReady)
+	}
+	SendNdtMessage(ndt.TestStart, "", ws)
+	s2cBytesPerSecond := <-tr.Result
+	s2cKbps := 8 * s2cBytesPerSecond / 1000.0
+
+	// Send additional download results to the client.
+	resultMsg := &NdtS2CResult{
+		ThroughputValue:  s2cKbps,
+		UnsentDataAmount: 0,
+		TotalSentByte:    int64(10 * s2cBytesPerSecond), // TODO: use actual bytes sent.
+	}
+	err := WriteNdtMessage(ws, ndt.TestMsg, resultMsg)
+	if err != nil {
+		return 0, fmt.Errorf("S2C: Failed to write JSON message: %s", err)
+	}
+	clientRateMsg, err := RecvNdtJSONMessage(ws, ndt.TestMsg)
+	if err != nil {
+		return 0, fmt.Errorf("S2C: Failed to read JSON message: %s", err)
+	}
+	log.Println("S2C: The client sent us:", clientRateMsg.Msg)
+	requiredWeb100Vars := []string{"MaxRTT", "MinRTT"}
+
+	for _, web100Var := range requiredWeb100Vars {
+		SendNdtMessage(ndt.TestMsg, web100Var+": 0", ws)
+	}
+	SendNdtMessage(ndt.TestFinalize, "", ws)
+	clientRate, err := strconv.ParseFloat(clientRateMsg.Msg, 64)
+	if err != nil {
+		return 0, fmt.Errorf("S2C: Bad client rate: %s", err)
+	}
+	log.Println("S2C: server rate:", s2cKbps, "vs client rate:", clientRate)
+	return s2cKbps, nil
+}
+
+// runS2C performs a 10 second NDT server to client test. Runtime is
+// guaranteed to be no more than timeout. The timeout should be slightly greater
+// than 10 sec. The given websocket should be closed by the caller.
+func runS2C(ws *websocket.Conn, data []byte, timeout time.Duration) float64 {
+	done := make(chan float64)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	go func() {
+		bytesPerSec, err := sendUntil(ws, data, 10*time.Second)
+		if err != nil {
+			cancel()
+			log.Println("S2C: sendUntil error:", err)
+			return
+		}
+		done <- bytesPerSec
+	}()
+
+	log.Println("S2C: Waiting for test to complete or timeout")
+	select {
+	case <-ctx.Done():
+		log.Println("S2C: Context Done!", ctx.Err())
+		// Return zero on error.
+		return 0
+	case bytesPerSecond := <-done:
+		return bytesPerSecond
+	}
+}
+
+func sendUntil(ws *websocket.Conn, data []byte, duration time.Duration) (float64, error) {
+	msg, err := websocket.NewPreparedMessage(websocket.BinaryMessage, data)
+	if err != nil {
+		return 0, fmt.Errorf("ERROR S2C: Could not make prepared message: %s", err)
+	}
+
+	totalBytes := float64(0)
+	startTime := time.Now()
+	endTime := startTime.Add(duration)
+	for time.Now().Before(endTime) {
+		err := ws.WritePreparedMessage(msg)
+		if err != nil {
+			return 0, fmt.Errorf("ERROR S2C: sending message: %s", err)
+		}
+		totalBytes += float64(len(data))
+	}
+	return totalBytes / float64(time.Since(startTime)/time.Second), nil
+}

--- a/ndt-server.go
+++ b/ndt-server.go
@@ -218,7 +218,7 @@ func manageC2sTest(ws *websocket.Conn) (float64, error) {
 	serveMux.HandleFunc("/ndt_protocol",
 		promhttp.InstrumentHandlerCounter(
 			testCount.MustCurryWith(prometheus.Labels{"direction": "c2s"}),
-			http.HandlerFunc(testResponder.C2STestServer)))
+			http.HandlerFunc(testResponder.C2STestHandler)))
 	err := testResponder.StartTLSAsync(serveMux)
 	if err != nil {
 		return 0, err
@@ -230,10 +230,10 @@ func manageC2sTest(ws *websocket.Conn) (float64, error) {
 	defer cancel()
 
 	go func() {
-		c2sKbps, err := testResponder.ControlC2S(ws)
+		c2sKbps, err := testResponder.C2SController(ws)
 		if err != nil {
 			cancel()
-			log.Println("C2S: ControlC2S error:", err)
+			log.Println("C2S: C2SController error:", err)
 			return
 		}
 		done <- c2sKbps

--- a/ndt-server_test.go
+++ b/ndt-server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"runtime"
 	"testing"
+	"time"
 
 	pipe "gopkg.in/m-lab/pipe.v3"
 )
@@ -78,6 +79,8 @@ func Test_NDTe2e(t *testing.T) {
 			t.Errorf("ERROR Command: %s\nStdout: %s\nStderr: %s\n",
 				testCmd, string(stdout), string(stderr))
 		}
+		// Add small delay to allow transient goroutines to quiesce.
+		time.Sleep(100 * time.Millisecond)
 		after := runtime.NumGoroutine()
 		if before != after {
 			t.Errorf("After running %s NumGoroutines changed: %d to %d",

--- a/ndt/const.go
+++ b/ndt/const.go
@@ -18,3 +18,9 @@ const (
 	TestS2C    = 4
 	TestStatus = 16
 )
+
+// Message constants for use in their respective channels
+const (
+	ReadyC2S = float64(-1)
+	ReadyS2C = float64(-1)
+)

--- a/ndt/const.go
+++ b/ndt/const.go
@@ -1,0 +1,20 @@
+package ndt
+
+// Message constants for the NDT protocol
+const (
+	SrvQueue         = byte(1)
+	MsgLogin         = byte(2)
+	TestPrepare      = byte(3)
+	TestStart        = byte(4)
+	TestMsg          = byte(5)
+	TestFinalize     = byte(6)
+	MsgError         = byte(7)
+	MsgResults       = byte(8)
+	MsgLogout        = byte(9)
+	MsgWaiting       = byte(10)
+	MsgExtendedLogin = byte(11)
+
+	TestC2S    = 2
+	TestS2C    = 4
+	TestStatus = 16
+)


### PR DESCRIPTION
This change begins to refactor the content of ndt-server.go into separate packages.

Specifically, the `TestResponder` implementation is renamed to the `legacy.Responder` in the legacy package.

`legacy/c2s.go` and `legacy/s2c.go` contain the logic necessary for each operation and follow a similar pattern each.

* `{C2S,S2C}TestHandler` - the handler used by the test server started in the control channel that runs the actual test.
* `{C2S,S2C}Controller` - the complementary logic to the test handler called from the control channel.
* `run{C2S,S2C}` - simple timeout wrappers around `{send,recv}Until`
* `{send,recv}Until` - the transfer loops underlying the S2C and C2S tests.

As well, this change adds the `ndt/const.go` file for constants shared across packages.

And, the content of ndt-server.go is minimized. the `NdtServer` handler for the control channel should be moved in a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-cloud/16)
<!-- Reviewable:end -->
