### PR TITLE
Finish simplifying ndt7 client

### DIFF
--- a/cmd/ndt-cloud-client/main.go
+++ b/cmd/ndt-cloud-client/main.go
@@ -1,46 +1,28 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"os"
-	"os/signal"
-	"runtime"
-	"syscall"
 
 	"github.com/apex/log"
 	"github.com/m-lab/ndt-cloud/ndt7"
 )
 
-var disableTLS = flag.Bool("disable-tls", false, "Whether to disable TLS")
-var duration = flag.Int("duration", 10, "Desired duration")
 var hostname = flag.String("hostname", "localhost", "Host to connect to")
-var port = flag.String("port", "3001", "Port to connect to")
+var port = flag.String("port", "3010", "Port to connect to")
 var skipTLSVerify = flag.Bool("skip-tls-verify", false, "Skip TLS verify")
 
 func main() {
 	flag.Parse()
-	settings := ndt7.Settings{}
-	settings.Hostname = *hostname
-	settings.InsecureNoTLS = *disableTLS
-	settings.InsecureSkipTLSVerify = *skipTLSVerify
-	settings.Port = *port
-	settings.Duration = *duration
-	clnt := ndt7.NewClient(settings)
-	ch := make(chan interface{}, 1)
-	defer close(ch)
-	sigs := make(chan os.Signal, 1)
-	defer close(sigs)
-	if runtime.GOOS != "windows" {
-		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-		go func() {
-			<-sigs
-			log.Warn("Got interrupt signal")
-			ch <- false
-			log.Warn("Delivered interrupt signal")
-		}()
+	clnt := ndt7.Client{}
+	clnt.URL.Scheme = "wss"
+	clnt.URL.Host = *hostname + ":" + *port
+	if *skipTLSVerify {
+		config := tls.Config{InsecureSkipVerify: true}
+		clnt.Dialer.TLSClientConfig = &config
 	}
-	err := clnt.Download()
-	if err != nil {
+	if err := clnt.Download(); err != nil {
 		log.WithError(err).Warn("clnt.Download() failed")
 		os.Exit(1)
 	}

--- a/ndt7/client.go
+++ b/ndt7/client.go
@@ -1,77 +1,19 @@
 package ndt7
 
 import (
-	"crypto/tls"
 	"encoding/json"
-	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/apex/log"
 	"github.com/gorilla/websocket"
 )
 
-// Settings contains client settings. All settings are optional except for
-// the Hostname, which cannot be autoconfigured at the moment.
-type Settings struct {
-	// This structure embeds options defined in the spec.
-	Options
-	// InsecureSkipTLSVerify can be used to disable certificate verification.
-	InsecureSkipTLSVerify bool `json:"skip_tls_verify"`
-	// InsecureNoTLS can be used to force using cleartext.
-	InsecureNoTLS bool `json:"no_tls"`
-	// Hostname is the hostname of the NDT7 server to connect to.
-	Hostname string `json:"hostname"`
-	// Port is the port of the NDT7 server to connect to.
-	Port string `json:"port"`
-}
-
-// Client is a NDT7 client.
+// Client is a simplified NDT7 client.
 type Client struct {
-	dialer websocket.Dialer
-	url    url.URL
-}
-
-// NewClient creates a new client.
-func NewClient(settings Settings) Client {
-	cl := Client{}
-	cl.dialer.HandshakeTimeout = defaultTimeout
-	if settings.InsecureSkipTLSVerify {
-		config := tls.Config{InsecureSkipVerify: true}
-		cl.dialer.TLSClientConfig = &config
-		log.Warn("Disabling TLS cerificate verification (INSECURE!)")
-	}
-	if settings.InsecureNoTLS {
-		log.Warn("Using plain text WebSocket (INSECURE!)")
-		cl.url.Scheme = "ws"
-	} else {
-		cl.url.Scheme = "wss"
-	}
-	if settings.Port != "" {
-		ip := net.ParseIP(settings.Hostname)
-		if ip == nil || len(ip) == 4 {
-			cl.url.Host = settings.Hostname
-			cl.url.Host += ":"
-			cl.url.Host += settings.Port
-		} else if len(ip) == 16 {
-			cl.url.Host = "["
-			cl.url.Host += settings.Hostname
-			cl.url.Host += "]:"
-			cl.url.Host += settings.Port
-		} else {
-			panic("IP address that is neither 4 nor 16 bytes long")
-		}
-	} else {
-		cl.url.Host = settings.Hostname
-	}
-	query := cl.url.Query()
-	if settings.Duration > 0 {
-		query.Add("duration", strconv.Itoa(settings.Duration))
-	}
-	cl.url.RawQuery = query.Encode()
-	return cl
+	Dialer websocket.Dialer
+	URL    url.URL
 }
 
 // defaultTimeout is the default value of the I/O timeout.
@@ -79,18 +21,32 @@ const defaultTimeout = 1 * time.Second
 
 // Download runs a NDT7 download test.
 func (cl Client) Download() error {
-	log.Info("Creating a WebSocket connection")
-	cl.url.Path = DownloadURLPath
+	cl.URL.Path = DownloadURLPath
+	log.Infof("Creating a WebSocket connection to: %s", cl.URL.String())
 	headers := http.Header{}
 	headers.Add("Sec-WebSocket-Protocol", SecWebSocketProtocol)
-	conn, _, err := cl.dialer.Dial(cl.url.String(), headers)
+	conn, _, err := cl.Dialer.Dial(cl.URL.String(), headers)
 	if err != nil {
 		return err
 	}
 	conn.SetReadLimit(MinMaxMessageSize)
 	defer conn.Close()
+	t0 := time.Now()
+	num := int64(0)
+	ticker := time.NewTicker(MinMeasurementInterval)
 	log.Info("Starting download")
 	for {
+		select {
+		case t1 := <-ticker.C:
+			// Print the current speed on the stdout because this gives us an idea
+			// of how fast we are downloading from the remote server.
+			v := (float64(num) * 8.0) / t1.Sub(t0).Seconds() / 1e06
+			log.Infof("Client measurement: %02f Mbit/s", v)
+			t0 = t1
+			num = int64(0)
+		default:
+			// Just fallthrough
+		}
 		conn.SetReadDeadline(time.Now().Add(defaultTimeout))
 		mtype, mdata, err := conn.ReadMessage()
 		if err != nil {
@@ -99,14 +55,15 @@ func (cl Client) Download() error {
 			}
 			break
 		}
+		num += int64(len(mdata))
 		if mtype == websocket.TextMessage {
-			// Unmarshaling to verify that this message is correct JSON
+			// Unmarshal to verify that this message is correct JSON but do not
+			// otherwise process the message's content.
 			measurement := Measurement{}
 			err := json.Unmarshal(mdata, &measurement)
 			if err != nil {
 				return err
 			}
-			log.Infof("Server measurement: %s", mdata)
 		}
 	}
 	log.Info("Download complete")


### PR DESCRIPTION
Attempt to remove any remaining optional complexity. Slightly
tweak the code such that we print the current speed on the
standard output, which helps to estimate whether we're doing
a good job when downloading from the local host.

Closes #18.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-cloud/19)
<!-- Reviewable:end -->
