### PR TITLE
Improvements after testing on 2G/3G/4G networks

### DIFF
--- a/bbr/bbr.go
+++ b/bbr/bbr.go
@@ -38,7 +38,7 @@
 //
 // 5. we defer *os.File.Close() until the end of the WebSocket serving loop and
 //    periodically we use such file to obtain the file descriptor and read the
-//    BBR variables using bbr.GetBandwidthAndRTT().
+//    BBR variables using bbr.GetMaxBandwidthAndMinRTT().
 //
 // Because a connection might be closed between steps 2. and 3. (i.e. after
 // the connection is accepted and before the HTTP layer finishes reading the
@@ -163,13 +163,13 @@ func GetAndForgetFile(conn net.Conn) *os.File {
 	return entry.Fp // Pass ownership to caller
 }
 
-// GetBandwidthAndRTT obtains BBR info from |fp|. The returned values are
+// GetMaxBandwidthAndMinRTT obtains BBR info from |fp|. The returned values are
 // the max-bandwidth in bits per second and the min-rtt in milliseconds.
-func GetBandwidthAndRTT(fp *os.File) (float64, float64, error) {
+func GetMaxBandwidthAndMinRTT(fp *os.File) (float64, float64, error) {
 	// Implementation note: for simplicity I have decided to use float64 here
 	// rather than uint64, mainly because the proper C type to use AFAICT (and
 	// I may be wrong here) changes between 32 and 64 bit. That is, it is not
 	// clear to me how to use a 64 bit integer (which I what I would have used
 	// by default) on a 32 bit system. So let's use float64.
-	return getBandwidthAndRTT(fp)
+	return getMaxBandwidthAndMinRTT(fp)
 }

--- a/bbr/bbr_linux.c
+++ b/bbr/bbr_linux.c
@@ -4,7 +4,6 @@
 #include <netinet/tcp.h>
 
 #include <errno.h>
-#include <stdint.h>
 #include <string.h>
 
 int get_bbr_info(int fd, double *bw, double *rtt) {

--- a/bbr/bbr_linux.go
+++ b/bbr/bbr_linux.go
@@ -22,7 +22,15 @@ func getBandwidthAndRTT(fp *os.File) (float64, float64, error) {
 	// Note: Fd() returns uintptr but on Unix we can safely use int for sockets.
 	rv := C.get_bbr_info(C.int(fp.Fd()), &bw, &rtt)
 	if rv != 0 {
-		return 0.0, 0.0, syscall.Errno(rv)
+		// C.get_bbr_info returns ENOSYS when the system does not support BBR. In
+		// such case let us map the error to ErrNoSupport, such that this Linux
+		// system looks like any other system where BBR is not available. This way
+		// the code for dealing with this error is not platform dependent.
+		err := syscall.Errno(rv)
+		if err == syscall.ENOSYS {
+			return 0.0, 0.0, ErrNoSupport
+		}
+		return 0.0, 0.0, err
 	}
 	return float64(bw), float64(rtt), nil
 }

--- a/bbr/bbr_linux.go
+++ b/bbr/bbr_linux.go
@@ -16,7 +16,7 @@ func enableBBR(fp *os.File) error {
 		syscall.TCP_CONGESTION, "bbr")
 }
 
-func getBandwidthAndRTT(fp *os.File) (float64, float64, error) {
+func getMaxBandwidthAndMinRTT(fp *os.File) (float64, float64, error) {
 	bw := C.double(0)
 	rtt := C.double(0)
 	// Note: Fd() returns uintptr but on Unix we can safely use int for sockets.

--- a/bbr/bbr_linux.h
+++ b/bbr/bbr_linux.h
@@ -5,8 +5,8 @@ extern "C" {
 #endif
 
 /* get_bbr_info retrieves BBR info from |fd| and stores them in |bw| and
-   |rtt| respectively. The bandwidth, |bw|, will be in bits per second, while
-   the RTT, |rtt|, will be in milliseconds. On success, returns zero. On
+   |rtt| respectively. The max-bandwidth, |bw|, will be in bits per second, and
+   the min-RTT, |rtt|, will be in milliseconds. On success, returns zero. On
    failure returns a nonzero errno value indicating the error that occurred. */
 int get_bbr_info(int fd, double *bw, double *rtt);
 

--- a/bbr/bbr_stub.go
+++ b/bbr/bbr_stub.go
@@ -10,6 +10,6 @@ func enableBBR(*os.File) error {
 	return ErrNoSupport
 }
 
-func getBandwidthAndRTT(*os.File) (float64, float64, error) {
+func getMaxBandwidthAndMinRTT(*os.File) (float64, float64, error) {
 	return 0.0, 0.0, ErrNoSupport
 }

--- a/html/libndt7.js
+++ b/html/libndt7.js
@@ -12,7 +12,8 @@ const libndt7 = (function () {
     open: 'ndt7.open',
 
     // close is the event emitted when the socket is closed. The
-    // object bound to this event is always null.
+    // object bound to this event is always null. The code SHOULD
+    // always emit this event at the end of the test.
     close: 'ndt7.close',
 
     // error is the event emitted when the socket is closed. The

--- a/html/libndt7.js
+++ b/html/libndt7.js
@@ -26,9 +26,11 @@ const libndt7 = (function () {
     downloadClient: 'ndt7.download.client'
   }
 
+  const version = 0.4
+
   return {
     // version is the client library version.
-    version: 0.3,
+    version: version,
 
     // events exports the events table.
     events: events,
@@ -52,7 +54,26 @@ const libndt7 = (function () {
         if (settings.port) {
           url += ':' + settings.port
         }
-        return url + '/ndt/v7/download'
+        url += '/ndt/v7/download?'
+        for (let key in settings.meta) {
+          if (settings.meta.hasOwnProperty(key)) {
+            const re = /[0-9A-Za-z._]+/
+            if (!key.match(re)) {
+              throw 'Key does not match the expected regular expression: ' + key
+            }
+            let value = settings.meta[key]
+            if (typeof value === 'number' || typeof value === 'boolean') {
+              value += ''  // force conversion to string
+            }
+            if (typeof value !== 'string' || !value.match(re)) {
+              throw 'Value is not a string or does not match the expected ' +
+                    'regular expression: ' + value
+            }
+            url += key + '=' + value + '&'
+          }
+        }
+        url += 'library.name=libndt7.js&library.version=' + version
+        return url
       }
 
       // setupconn creates the WebSocket connection and initializes all

--- a/html/libndt7.js
+++ b/html/libndt7.js
@@ -30,7 +30,7 @@ const libndt7 = (function () {
     downloadClient: 'ndt7.download.client'
   }
 
-  const version = 0.4
+  const version = 0.5
 
   return {
     // version is the client library version.
@@ -56,25 +56,14 @@ const libndt7 = (function () {
         url.protocol = (url.protocol === 'https:') ? 'wss:' : 'ws:'
         url.pathname = '/ndt/v7/download'
         let params = new URLSearchParams()
+        settings.meta = (settings.meta !== undefined) ? settings : {}
+        settings.meta['library.name'] = 'libndt7.js'
+        settings.meta['library.version'] = version
         for (let key in settings.meta) {
           if (settings.meta.hasOwnProperty(key)) {
-            const re = /[0-9A-Za-z._]+/
-            if (!key.match(re)) {
-              throw 'Key does not match the expected regular expression: ' + key
-            }
-            let value = settings.meta[key]
-            if (typeof value === 'number' || typeof value === 'boolean') {
-              value += ''  // force conversion to string
-            }
-            if (typeof value !== 'string' || !value.match(re)) {
-              throw 'Value is not a string or does not match the expected ' +
-                    'regular expression: ' + value
-            }
-            params.append(key, value)
+            params.append(key, settings.meta[key])
           }
         }
-        params.append('library.name', 'libndt7')
-        params.append('library.version', version)
         url.search = params.toString()
         return url.toString()
       }

--- a/html/libndt7.js
+++ b/html/libndt7.js
@@ -1,3 +1,6 @@
+/* jshint esversion: 6, asi: true */
+/* exported libndt7 */
+
 // libndt7 is a NDTv7 client library in JavaScript.
 const libndt7 = (function () {
   'use strict';

--- a/html/libndt7.js
+++ b/html/libndt7.js
@@ -52,13 +52,10 @@ const libndt7 = (function () {
 
       // makeurl creates the URL from |settings|.
       const makeurl = function (settings) {
-        let url = ''
-        url += (settings.insecure) ? 'ws://' : 'wss://'
-        url += settings.hostname
-        if (settings.port) {
-          url += ':' + settings.port
-        }
-        url += '/ndt/v7/download?'
+        let url = new URL(settings.href)
+        url.protocol = (url.protocol === 'https:') ? 'wss:' : 'ws:'
+        url.pathname = '/ndt/v7/download'
+        let params = new URLSearchParams()
         for (let key in settings.meta) {
           if (settings.meta.hasOwnProperty(key)) {
             const re = /[0-9A-Za-z._]+/
@@ -73,11 +70,13 @@ const libndt7 = (function () {
               throw 'Value is not a string or does not match the expected ' +
                     'regular expression: ' + value
             }
-            url += key + '=' + value + '&'
+            params.append(key, value)
           }
         }
-        url += 'library.name=libndt7.js&library.version=' + version
-        return url
+        params.append('library.name', 'libndt7')
+        params.append('library.version', version)
+        url.search = params.toString()
+        return url.toString()
       }
 
       // setupconn creates the WebSocket connection and initializes all

--- a/html/libndt7.js
+++ b/html/libndt7.js
@@ -107,7 +107,7 @@ const libndt7 = (function () {
           if (event.data instanceof Blob) {
             count += event.data.size
           } else {
-            emit(events.downloadServer, event.data)
+            emit(events.downloadServer, JSON.parse(event.data))
             count += event.data.length
           }
           let t1 = new Date().getTime()

--- a/html/ndt7-worker.js
+++ b/html/ndt7-worker.js
@@ -1,0 +1,38 @@
+/* jshint esversion: 6, asi: true */
+/* globals importScripts, onmessage: true, postMessage, libndt7 */
+
+// ndt7-worker is a Web Worker that runs the ndt7 nettest in a background
+// thread of execution, so we do not block the user interface.
+
+importScripts('libndt7.js')
+
+// onmessage receives a key, value message requesting to start a ndt7
+// subtest. The key is the subtest type. The value is an object containing
+// the settings to be used by the subtest. The worker routes the events
+// emitted during the execution of the ndt7 subtest to the main thread using
+// again a key, value message. This time the key is the type of event that
+// has been emitted and the value is the corresponding object.
+onmessage = function (ev) {
+  'use strict'
+  const msg = ev.data
+  if (msg.key === 'download') {
+    const settings = msg.value
+    let clnt = libndt7.newClient(settings)
+    for (const key in libndt7.events) {
+      if (libndt7.events.hasOwnProperty(key)) {
+        clnt.on(libndt7.events[key], function (value) {
+          postMessage({
+            key: libndt7.events[key],
+            value: value,
+          })
+        })
+      }
+    }
+    clnt.startDownload()
+  } else {
+    postMessage({
+      key: libndt7.events.error,
+      value: 'Subtest not implemented: ' + msg.key,
+    })
+  }
+}

--- a/html/ndt7-worker.js
+++ b/html/ndt7-worker.js
@@ -34,5 +34,9 @@ onmessage = function (ev) {
       key: libndt7.events.error,
       value: 'Subtest not implemented: ' + msg.key,
     })
+    postMessage({
+      key: libndt7.events.close,
+      value: null
+    })
   }
 }

--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -60,7 +60,7 @@
             if (d.bbr_info) {
               let mbits = d.bbr_info.bandwidth / 1000 / 1000
               row.insertCell().innerHTML = mbits.toFixed(3)
-              row.insertCell().innerHTML = d.bbr_info.RTT
+              row.insertCell().innerHTML = d.bbr_info.rtt
             } else {
               row.insertCell().innerHTML = 'N/A'
               row.insertCell().innerHTML = 'N/A'

--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -8,8 +8,8 @@
 <body>
   <table>
     <thead><tr>
-      <th>Elapsed (s)</th><th>Transferred (MiB)</th><th>Bandwidth (Mbit/s)</th>
-        <th>RTT (ms)</th>
+      <th>Elapsed (s)</th><th>Transferred (MiB)</th>
+        <th>Max Bandwidth (Mbit/s)</th><th>Min RTT (ms)</th>
     </tr><thead>
     <tbody id='measurement'></tbody>
   </table>
@@ -58,9 +58,9 @@
             row.insertCell().innerHTML = d.elapsed.toFixed(3)
             row.insertCell().innerHTML = (d.num_bytes / 1024 / 1024).toFixed(3)
             if (d.bbr_info) {
-              let mbits = d.bbr_info.bandwidth / 1000 / 1000
+              let mbits = d.bbr_info.max_bandwidth / 1000 / 1000
               row.insertCell().innerHTML = mbits.toFixed(3)
-              row.insertCell().innerHTML = d.bbr_info.rtt
+              row.insertCell().innerHTML = d.bbr_info.min_rtt
             } else {
               row.insertCell().innerHTML = 'N/A'
               row.insertCell().innerHTML = 'N/A'

--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -9,35 +9,38 @@
   <button onclick='Run()'>Run</button>
   <div id='measurement'></div>
   <script type='text/javascript'>
+    /* jshint esversion: 6, asi: true */
+    /* exported Run */
+    /* globals libndt7 */
     function Run() {
-      let clnt = libndt7.newClient({
-        insecure: (window.location.protocol !== 'https:'),
-        hostname: window.location.host,
-        download: {
-          duration: 4,
-          adaptive: true
+      let worker = new Worker('ndt7-worker.js')
+      worker.postMessage({
+        key: 'download',
+        value: {
+          insecure: (window.location.protocol !== 'https:'),
+          hostname: window.location.host,
+        },
+      })
+      worker.onmessage = function (ev) {
+        const msg = ev.data
+        if (msg.key === libndt7.events.open) {
+          console.log('Open: ' + JSON.stringify(msg.value))
+        } else if (msg.key === libndt7.events.close) {
+          console.log('Close: ' + JSON.stringify(msg.value))
+        } else if (msg.key === libndt7.events.error) {
+          console.log('Error: ' + JSON.stringify(msg.value))
+        } else if (msg.key === libndt7.events.downloadClient) {
+          console.log('Measurement from us: ' + JSON.stringify(msg.value))
+        } else if (msg.key === libndt7.events.downloadServer) {
+          console.log('Measurement from server: ' + JSON.stringify(msg.value))
+          const elem = document.getElementById('measurement')
+          if (elem) {
+            elem.innerHTML += '<p>' + JSON.stringify(msg.value) + '</p>'
+          }
+        } else {
+          console.log('Received unexpected message: ' + msg.key)
         }
-      })
-      clnt.on(libndt7.events.open, function (value) {
-        console.log('Open: ' + JSON.stringify(value))
-      })
-      clnt.on(libndt7.events.close, function (value) {
-        console.log('Close: ' + JSON.stringify(value))
-      })
-      clnt.on(libndt7.events.error, function (value) {
-        console.log('Error: ' + JSON.stringify(value))
-      })
-      clnt.on(libndt7.events.downloadClient, function (value) {
-        console.log('Measurement from us: ' + JSON.stringify(value))
-      })
-      clnt.on(libndt7.events.downloadServer, function (value) {
-        console.log('Measurement from server: ' + JSON.stringify(value))
-        const elem = document.getElementById('measurement')
-        if (elem) {
-          elem.innerHTML += '<p>' + JSON.stringify(value) + '</p>'
-        }
-      })
-      clnt.startDownload()
+      }
     }
   </script>
 </body>

--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -35,8 +35,7 @@
       worker.postMessage({
         key: 'download',
         value: {
-          insecure: (window.location.protocol !== 'https:'),
-          hostname: window.location.host,
+          href: window.location.href
         },
       })
       worker.onmessage = function (ev) {
@@ -51,7 +50,8 @@
           console.log('Measurement from us: ' + JSON.stringify(msg.value))
         } else if (msg.key === libndt7.events.downloadServer) {
           const d = msg.value
-          console.log('Measurement from server: ' + JSON.stringify(d))
+          // Enable only for debugging. Will overload the browser.
+          //console.log('Measurement from server: ' + JSON.stringify(d))
           WithMeasurementDo(function (elem) {
             elem.innerHTML = ''
             let row = elem.insertRow()

--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -7,12 +7,31 @@
 </head>
 <body>
   <button onclick='Run()'>Run</button>
-  <div id='measurement'></div>
+  <table>
+    <thead><tr>
+      <th>Elapsed (s)</th><th>Transferred (MiB)</th><th>Bandwidth (Mbit/s)</th>
+        <th>RTT (ms)</th>
+    </tr><thead>
+    <tbody id='measurement'></tbody>
+  </table>
+  <table id='measurement'></table>
   <script type='text/javascript'>
     /* jshint esversion: 6, asi: true */
     /* exported Run */
     /* globals libndt7 */
+
+    function WithMeasurementDo(callable) {
+      const elem = document.getElementById('measurement')
+      if (elem) {
+        callable(elem)
+      }
+    }
+
     function Run() {
+      WithMeasurementDo(function (elem) {
+        elem.innerHTML = ''
+      })
+
       let worker = new Worker('ndt7-worker.js')
       worker.postMessage({
         key: 'download',
@@ -32,16 +51,27 @@
         } else if (msg.key === libndt7.events.downloadClient) {
           console.log('Measurement from us: ' + JSON.stringify(msg.value))
         } else if (msg.key === libndt7.events.downloadServer) {
-          console.log('Measurement from server: ' + JSON.stringify(msg.value))
-          const elem = document.getElementById('measurement')
-          if (elem) {
-            elem.innerHTML += '<p>' + JSON.stringify(msg.value) + '</p>'
-          }
+          const d = msg.value
+          console.log('Measurement from server: ' + JSON.stringify(d))
+          WithMeasurementDo(function (elem) {
+            let row = elem.insertRow()
+            row.insertCell().innerHTML = d.elapsed.toFixed(3)
+            row.insertCell().innerHTML = (d.num_bytes / 1024 / 1024).toFixed(3)
+            if (d.bbr_info) {
+              let mbits = d.bbr_info.bandwidth / 1000 / 1000
+              row.insertCell().innerHTML = mbits.toFixed(3)
+              row.insertCell().innerHTML = d.bbr_info.RTT
+            } else {
+              row.insertCell().innerHTML = 'N/A'
+              row.insertCell().innerHTML = 'N/A'
+            }
+          })
         } else {
           console.log('Received unexpected message: ' + msg.key)
         }
       }
     }
+
   </script>
 </body>
 </html>

--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -53,6 +53,7 @@
           const d = msg.value
           console.log('Measurement from server: ' + JSON.stringify(d))
           WithMeasurementDo(function (elem) {
+            elem.innerHTML = ''
             let row = elem.insertRow()
             row.insertCell().innerHTML = d.elapsed.toFixed(3)
             row.insertCell().innerHTML = (d.num_bytes / 1024 / 1024).toFixed(3)

--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -6,7 +6,6 @@
   <title>ndt7 Browser Client</title>
 </head>
 <body>
-  <button onclick='Run()'>Run</button>
   <table>
     <thead><tr>
       <th>Elapsed (s)</th><th>Transferred (MiB)</th><th>Bandwidth (Mbit/s)</th>
@@ -72,6 +71,7 @@
       }
     }
 
+    Run()  // When you load the page
   </script>
 </body>
 </html>

--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -13,7 +13,7 @@
     </tr><thead>
     <tbody id='measurement'></tbody>
   </table>
-  <table id='measurement'></table>
+  <table></table>
   <script type='text/javascript'>
     /* jshint esversion: 6, asi: true */
     /* exported Run */

--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -9,7 +9,7 @@
   <table>
     <thead><tr>
       <th>Elapsed (s)</th><th>Transferred (MiB)</th>
-        <th>Max Bandwidth (Mbit/s)</th><th>Min RTT (ms)</th>
+        <th>MaxBandwidth (Mbit/s)</th><th>MinRTT (ms)</th>
     </tr><thead>
     <tbody id='measurement'></tbody>
   </table>

--- a/ndt-server.go
+++ b/ndt-server.go
@@ -133,13 +133,13 @@ func (ln tcpListenerEx) Accept() (net.Conn, error) {
 	if ln.TryToEnableBBR {
 		err = bbr.EnableAndRememberFile(tc)
 		if err != nil && err != bbr.ErrNoSupport {
-			// This is the case in which we compiled in BBR support but something
-			// was wrong when enabling BBR at runtime. TODO(bassosimone): when we'll
-			// have BBR support on the whole fleet, here we should probably return
-			// an error rather than continuing. For now we'll tolerate.
 			log.Printf("Cannot initialize BBR: %s", err.Error())
-		} else if err == bbr.ErrNoSupport {
+			return nil, err
+		}
+		if err == bbr.ErrNoSupport {
 			log.Printf("Your system does not support BBR")
+			// Keep going. There are also old Linux servers without BBR and servers
+			// where the operating system is different from Linux.
 		}
 	}
 	return tc, nil

--- a/ndt-server.go
+++ b/ndt-server.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gorilla/handlers"
 	"github.com/gorilla/websocket"
 	"github.com/m-lab/ndt-cloud/ndt7"
 	"github.com/m-lab/ndt-cloud/bbr"
@@ -685,7 +686,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	s := &http.Server{Handler: http.DefaultServeMux}
+	s := &http.Server{Handler: handlers.LoggingHandler(
+			os.Stderr, http.DefaultServeMux)}
 	log.Fatal(s.ServeTLS(tcpListenerEx{TCPListener: ln, TryToEnableBBR: true},
 		*fCertFile, *fKeyFile))
 }

--- a/ndt7/client.go
+++ b/ndt7/client.go
@@ -10,6 +10,12 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// minMeasurementInterval is the minimum value of the interval betwen
+// two consecutive measurements performed by either party. An implementation
+// MAY choose to close the connection if it is receiving too frequent
+// Measurement messages from the other endpoint.
+const minMeasurementInterval = 250 * time.Millisecond
+
 // Client is a simplified ndt7 client.
 type Client struct {
 	Dialer websocket.Dialer
@@ -31,7 +37,7 @@ func (cl Client) Download() error {
 	defer conn.Close()
 	t0 := time.Now()
 	num := float64(0.0)
-	ticker := time.NewTicker(MinMeasurementInterval)
+	ticker := time.NewTicker(minMeasurementInterval)
 	log.Info("Starting download")
 	for {
 		select {

--- a/ndt7/client.go
+++ b/ndt7/client.go
@@ -17,7 +17,7 @@ type Client struct {
 }
 
 // defaultTimeout is the default value of the I/O timeout.
-const defaultTimeout = 1 * time.Second
+const defaultTimeout = 7 * time.Second
 
 // Download runs a ndt7 download test.
 func (cl Client) Download() error {

--- a/ndt7/client.go
+++ b/ndt7/client.go
@@ -16,9 +16,6 @@ type Client struct {
 	URL    url.URL
 }
 
-// defaultTimeout is the default value of the I/O timeout.
-const defaultTimeout = 7 * time.Second
-
 // Download runs a ndt7 download test.
 func (cl Client) Download() error {
 	cl.URL.Path = DownloadURLPath

--- a/ndt7/server.go
+++ b/ndt7/server.go
@@ -104,7 +104,9 @@ func downloadLoop(conn *websocket.Conn, fp *os.File) {
 			last = t
 			if stoppable {
 				log.Info("It seems we can stop the download earlier")
-				break
+				// Disable breaking out of the loop for now because we've determined
+				// that the best course of action is actually to run for 10 seconds to
+				// gather enough data to refine the "stop early" algorithm.
 			}
 		}
 		if time.Now().Sub(t0) >= defaultDuration {

--- a/ndt7/server.go
+++ b/ndt7/server.go
@@ -1,7 +1,8 @@
 package ndt7
 
 import (
-	"crypto/rand"
+	"encoding/json"
+	"math/rand"
 	"net/http"
 	"os"
 	"time"
@@ -57,70 +58,78 @@ func warnAndClose(writer http.ResponseWriter, message string) {
 	writer.WriteHeader(http.StatusBadRequest)
 }
 
+// makePadding generates a |size|-bytes long string containing random
+// characters extracted from the [A-Za-z] set.
+func makePadding(size int) string {
+	const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	data := make([]byte, size)
+	// This is not the fastest algorithm to generate a random string, yet it
+	// is most likely good enough for our purposes. See [1] for a comprehensive
+	// discussion regarding how to generate a random string in Golang.
+	//
+	// .. [1] https://stackoverflow.com/a/31832326/4354461
+	for i := range data {
+		data[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(data)
+}
+
 // downloadLoop loops until the download is complete. |conn| is the WebSocket
 // connection. |fp| is a os.File bound to the same descriptor of |conn| that
 // allows us to extract BBR stats on Linux systems.
 func downloadLoop(conn *websocket.Conn, fp *os.File) {
 	log.Debug("Generating random buffer")
 	const bufferSize = 1 << 13
-	data := make([]byte, bufferSize)
-	rand.Read(data)
-	buffer, err := websocket.NewPreparedMessage(websocket.BinaryMessage, data)
-	if err != nil {
-		log.WithError(err).Warn("websocket.NewPreparedMessage() failed")
-		return
-	}
+	padding := makePadding(bufferSize)
 	log.Debug("Start sending data to client")
 	t0 := time.Now()
-	last := t0
 	count := float64(0.0)
 	bandwidth := float64(0.0)
 	for {
 		t := time.Now()
-		if t.Sub(last) >= MinMeasurementInterval {
-			// TODO(bassosimone): here we should also include tcp_info data
-			elapsed := t.Sub(t0)
-			measurement := Measurement{
-				Elapsed:  elapsed.Seconds(),
-				NumBytes: count,
-			}
-			stoppable := false
-			if fp != nil {
-				bw, rtt, err := bbr.GetBandwidthAndRTT(fp)
-				if err == nil {
-					measurement.BBRInfo = &BBRInfo{
-						Bandwidth: bw,
-						RTT:       rtt,
-					}
-					log.Infof("BW: %f bit/s; RTT: %f ms", bw, rtt)
-					stoppable = stableAccordingToBBR(bandwidth, bw, rtt, elapsed)
-					bandwidth = bw
-				} else {
-					log.WithError(err).Warn("Cannot get BBR info")
+		// TODO(bassosimone): here we should also include tcp_info data
+		elapsed := t.Sub(t0)
+		measurement := Measurement{
+			Elapsed:  elapsed.Seconds(),
+			NumBytes: count,
+			Padding: padding,
+		}
+		stoppable := false
+		if fp != nil {
+			bw, rtt, err := bbr.GetBandwidthAndRTT(fp)
+			if err == nil {
+				measurement.BBRInfo = &BBRInfo{
+					Bandwidth: bw,
+					RTT:       rtt,
 				}
+				log.Infof("Elapsed: %f s; BW: %f bit/s; RTT: %f ms",
+						elapsed.Seconds(), bw, rtt)
+				stoppable = stableAccordingToBBR(bandwidth, bw, rtt, elapsed)
+				bandwidth = bw
+			} else {
+				log.WithError(err).Warn("Cannot get BBR info")
 			}
-			conn.SetWriteDeadline(time.Now().Add(defaultTimeout))
-			if err := conn.WriteJSON(&measurement); err != nil {
-				log.WithError(err).Warn("Cannot send measurement message")
-				return
-			}
-			last = t
-			if stoppable {
-				log.Info("It seems we can stop the download earlier")
-				// Disable breaking out of the loop for now because we've determined
-				// that the best course of action is actually to run for 10 seconds to
-				// gather enough data to refine the "stop early" algorithm.
-			}
+		}
+		conn.SetWriteDeadline(time.Now().Add(defaultTimeout))
+		data, err := json.Marshal(measurement)
+		if err != nil {
+			log.WithError(err).Warn("Cannot serialise measurement message")
+			return
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+			log.WithError(err).Warn("Cannot send serialised measurement message")
+			return
+		}
+		if stoppable {
+			log.Info("It seems we can stop the download earlier")
+			// Disable breaking out of the loop for now because we've determined
+			// that the best course of action is actually to run for 10 seconds to
+			// gather enough data to refine the "stop early" algorithm.
 		}
 		if time.Now().Sub(t0) >= defaultDuration {
 			break
 		}
-		conn.SetWriteDeadline(time.Now().Add(defaultTimeout))
-		if err := conn.WritePreparedMessage(buffer); err != nil {
-			log.WithError(err).Warn("cannot send data message")
-			return
-		}
-		count += bufferSize
+		count += float64(len(data))
 	}
 	log.Debug("Download test complete")
 }

--- a/ndt7/server.go
+++ b/ndt7/server.go
@@ -11,6 +11,9 @@ import (
 	"github.com/m-lab/ndt-cloud/bbr"
 )
 
+// defaultTimeout is the default value of the I/O timeout.
+const defaultTimeout = 7 * time.Second
+
 // defaultDuration is the default duration of a subtest in nanoseconds.
 const defaultDuration = 10 * time.Second
 

--- a/ndt7/spec.go
+++ b/ndt7/spec.go
@@ -4,8 +4,6 @@
 // https://github.com/m-lab/ndt-cloud/blob/master/spec/ndt7.md.
 package ndt7
 
-import "time"
-
 // DownloadURLPath selects the download subtest.
 const DownloadURLPath = "/ndt/v7/download"
 
@@ -46,9 +44,3 @@ type Measurement struct {
 	// messages could be used directly to generate network load.
 	Padding string `json:"padding,omitempty"`
 }
-
-// MinMeasurementInterval is the minimum value of the interval betwen
-// two consecutive measurements performed by either party. An implementation
-// MAY choose to close the connection if it is receiving too frequent
-// Measurement messages from the other endpoint.
-const MinMeasurementInterval = 250 * time.Millisecond

--- a/ndt7/spec.go
+++ b/ndt7/spec.go
@@ -22,11 +22,11 @@ const MinMaxMessageSize = 1 << 17
 
 // The BBRInfo struct contains information measured using BBR.
 type BBRInfo struct {
-	// Bandwidth is the bandwidth measured by BBR in bits per second.
-	Bandwidth float64 `json:"bandwidth"`
+	// MaxBandwidth is the max bandwidth measured by BBR in bits per second.
+	MaxBandwidth float64 `json:"max_bandwidth"`
 
-	// RTT is the RTT measured by BBR in milliseconds.
-	RTT float64 `json:"rtt"`
+	// MinRTT is the min RTT measured by BBR in milliseconds.
+	MinRTT float64 `json:"min_rtt"`
 }
 
 // The Measurement struct contains measurement results. This structure is

--- a/ndt7/spec.go
+++ b/ndt7/spec.go
@@ -40,6 +40,11 @@ type Measurement struct {
 
 	// BBRInfo is the data measured using TCP BBR instrumentation.
 	BBRInfo *BBRInfo `json:"bbr_info,omitempty"`
+
+	// Padding contains an optional random [A-Za-z]+ string that MAY be
+	// added by a server to send larger measurement message, so that such
+	// messages could be used directly to generate network load.
+	Padding string `json:"padding,omitempty"`
 }
 
 // MinMeasurementInterval is the minimum value of the interval betwen

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -7,7 +7,7 @@ protocol](https://github.com/ndt-project/ndt). Ndt7 is based on
 WebSocket and TLS, and takes advantage of TCP BBR, where this
 flavour of TCP is available.
 
-This is version v0.3.0 of the ndt7 specification.
+This is version v0.4.0 of the ndt7 specification.
 
 ## Protocol description
 
@@ -107,8 +107,8 @@ not parseable or not acceptable (see below). The server SHOULD store
 the metadata sent by the client using the query string.
 
 The following restrictions apply to the query string. It MUST NOT be
-longer than 4096 bytes. Both the name and the value of the query string
-parameters MUST match the `[0-9A-Za-z._]+` regular expression.
+longer than 4096 bytes. Of course, both the name and the value of the
+URL query string MUST be valid URL-encoded UTF-8 strings.
 
 ## Measurements message
 

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -119,8 +119,8 @@ structure:
 ```json
 {
   "bbr_info": {
-    "bandwidth": 12345.4,
-    "rtt": 123.4
+    "max_bandwidth": 12345.4,
+    "min_rtt": 123.4
   },
   "elapsed": 1.2345,
   "num_bytes": 17.0,
@@ -133,10 +133,10 @@ Where:
 - `bbr_info` is an _optional_ JSON object only included in the measurement
   when it is possible to access TCP BBR stats:
 
-    - `bbr_info.bandwidth` (a `float64`) is the max-bandwidth measured by BBR,
-       in bits per second;
+    - `bbr_info.max_bandwidth` (a `float64`) is the max-bandwidth measured by
+       BBR, in bits per second;
 
-    - `bbr_info.rtt` (a `float64`) is the min-rtt measured by BBR,
+    - `bbr_info.min_rtt` (a `float64`) is the min-rtt measured by BBR,
       in millisecond;
 
 - `elapsed` (a `float64`) is the number of seconds elapsed since the beginning

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -7,7 +7,7 @@ protocol](https://github.com/ndt-project/ndt). Ndt7 is based on
 WebSocket and TLS, and takes advantage of TCP BBR, where this
 flavour of TCP is available.
 
-This is version v0.2.0 of the ndt7 specification.
+This is version v0.3.0 of the ndt7 specification.
 
 ## Protocol description
 
@@ -60,30 +60,37 @@ exchange ndt7 messages using the WebSocket framing. An implementation MAY
 choose to limit the maximum WebSocket message size, but such limit MUST
 NOT be smaller than 1 << 17 bytes.
 
-Binary WebSocket messages will carry a body composed of random bytes and
-will be used to measure the network performance. In the download subtest
-these messages are sent by the server to the client. In the upload
-subtest the client will send binary messages to the server. If a binary
-message is received when it is not expected (i.e. the server receives
-a binary message during the download) the connection SHOULD be closed.
+Both textual and binary WebSocket messages are allowed. Textual WebSocket
+messages will contain serialised JSON structures containing measurements
+results (see below). Since both parties MAY in principle perform measurements
+during any subtest, both parties MAY send such textual messages.
 
-Textual WebSocket messages will contain serialized JSON stuctures
-containing measurement results (see below). This kind of messages
-MAY be sent by both the client and the server throughout the subtest,
-regardless of the test type, because both parties run network
-measurements they MAY want to share. Note: the bytes exhanged as
-part of the textual messages SHOULD themselves be useful to measure
-the network performance. An implementation MAY decide to close the
-connection if it is receiving Textual WebSocket messages more frequently
-than one every 250 millisecond.
+To generate network load, the party that is currently sending (i.e. the
+server during a download subtest) has two options:
 
-When the configured duration time has expired, the parties SHOULD close
+1. add a random padding string to each measurement JSON message;
+
+2. send, in addition to textual WebSocket messages, binary WebSocket
+   messages carrying random binary data.
+
+The party that is receiving MUST ignore random padding included in
+textual messages and binary messages. The party that is sending SHOULD
+close the connection if it receives textual messages with padding
+or binary messages, since such messages SHOULD only be used by the
+party that is sending to generate network load.
+
+The expected transfer time of each subtest is ten seconds (unless BBR
+is used, in which case it may be shorter, as explained below). The sender
+SHOULD stop sending after ten seconds. The receiver MAY close the
+connection if the transfer runs for more than fifteen seconds.
+
+When the expected transfer time has expired, the parties SHOULD close
 the WebSocket channel by sending a Close WebSocket frame. The client
-SHOULD not close the TCP connection immediately, so that the server can
+SHOULD NOT close the TCP connection immediately, so that the server can
 close it first. This allows to reuse ports more efficiently on the
-server because we avoid `TIME_WAIT`.
+server because we avoid the `TIME_WAIT` TCP state.
 
-## Availability of TCP BBR
+## Stopping the transfer earlier using BBR
 
 If TCP BBR is available, a compliant server MAY choose to enable it
 for the client connection and terminate the download test early when
@@ -111,16 +118,26 @@ structure:
 
 ```json
 {
-  "elapsed": 1.2345,
-  "num_bytes": 17.0,
   "bbr_info": {
     "bandwidth": 12345.4,
     "rtt": 123.4
-  }
+  },
+  "elapsed": 1.2345,
+  "num_bytes": 17.0,
+  "padding": "ABFHFghghghhghgFLLF..."
 }
 ```
 
 Where:
+
+- `bbr_info` is an _optional_ JSON object only included in the measurement
+  when it is possible to access TCP BBR stats:
+
+    - `bbr_info.bandwidth` (a `float64`) is the max-bandwidth measured by BBR,
+       in bits per second;
+
+    - `bbr_info.rtt` (a `float64`) is the min-rtt measured by BBR,
+      in millisecond;
 
 - `elapsed` (a `float64`) is the number of seconds elapsed since the beginning
   of the specific subtest;
@@ -128,15 +145,11 @@ Where:
 - `num_bytes` (a `float64`) is the number of bytes sent (or received) since the
   beginning of the specific subtest;
 
-- `bbr_info` is an optional JSON object only included in the measurement
-  when it is possible to access TCP BBR stats;
+- `padding` is an _optional_ string containing random uppercase and/or
+  lowercase letters that the sending party MAY choose to add to measurement
+  messages to generate network load, as explained above.
 
-- `bbr_info.bandwidth` (a `float64`) is the max-bandwidth measured by BBR, in
-   bits per second;
-
-- `bbr_info.rtt` (a `float64`) is the min-rtt measured by BBR, in millisecond.
-
-The reason why we always use `float64` (i.e. `double`) for all variables is
+The reason why we always use `float64` (i.e. `double`) for numeric variables is
 that this allows also 32 bit systems to handle such variables easily.
 
 # Reference implementation


### PR DESCRIPTION
I've run some more tests in 2G/3G/4G networks. This led me to the following improvements:

1. using a worker for the web client, so the UI is not locked

2. modify the protocol to allow for sending measurement messages with padding, so that the client receives more measurements regardless of the delay caused by 2G/3G/4G buffers

3. other, smaller, miscellaneous, useful fixes

I have also experimented with `TCP_NOTSENT_LOWAT` but that diff is not ready to be included in this PR yet, and I feel like the code in here has been delayed for too much time already. I'll probably ask about this option to @mattmathis later today or in the next days.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-cloud/33)
<!-- Reviewable:end -->
